### PR TITLE
make test_example a check_program

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,4 @@
-bin_PROGRAMS = test_example
+check_PROGRAMS = test_example
 test_example_SOURCES = test_example.c homfly.h
 test_example_LDADD = @top_builddir@/lib/libhomfly.la
 test_example_DEPENDENCIES = @top_builddir@/lib/libhomfly.la


### PR DESCRIPTION
bin_PROGRAMS are installed when you do make install. Not so check_PROGRAMS. We don't want test_example to be installed.
