### PR TITLE
sanitise global data allocation; fix a void return

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,6 @@ matrix:
         packages:
         - libgc-dev
 
-os:
-  - linux
-  - osx
-
-compiler:
-  - gcc
-  - clang
-
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bdw-gc  ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ compiler:
   - gcc
 before_install:
   - sudo apt-get install libgc-dev
-script: autoreconf --install && automake --add-missing --copy && ./configure && make check
+script: autoreconf --install &&  automake --add-missing --copy && ./configure && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,29 @@
 language: c
+
+matrix:
+  allow_failures:
+    - os: osx
+  include:
+  - os: osx
+    compiler: clang
+  - os: linux
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - libgc-dev
+
+os:
+  - linux
+  - osx
+
 compiler:
   - gcc
+  - clang
+
 before_install:
-  - sudo apt-get install libgc-dev
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bdw-gc  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libgc-dev ; fi
+
 script: autoreconf --install && automake --add-missing --copy && ./configure && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ compiler:
   - gcc
 before_install:
   - sudo apt-get install libgc-dev
-script: autoreconf --install &&  automake --add-missing --copy && ./configure && make check
+script: autoreconf --install && automake --add-missing --copy && ./configure && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: c
+compiler:
+  - gcc
+before_install:
+  - sudo apt-get install libgc-dev
+script: autoreconf --install && automake --add-missing --copy && ./configure && make check

--- a/lib/bound.c
+++ b/lib/bound.c
@@ -21,21 +21,21 @@ A step is either adding a crossing, adding a crossing and removing a pair of
 boundary crossings, or just removing a pair of boundary crossings.
 ------------------------------------------------------------------------------
 */
+word list[BIGWEAVE];              /* description of first new weave */
+word list2[BIGWEAVE];           /* description of second, if needed */
+word old_going_in[BIGWEAVE];/* Was *i* an input? *old_going_in[i]*. */
+word going_in[BIGWEAVE];    /* Will *i* be an input? *going_in[i]*. */
+word map[BIGWEAVE];   /* i of old weave becomes map[i] of new weave */
+word first;                    /* first boundary crossing to remove */
+word second;                  /* second boundary crossing to remove */
+word right;          /* Is the crossing being added be righthanded? */
+word oldcross;     /* number of boundary crossings in the old weave */
+word newcross;    /* number of boundary crossings in each new weave */
+word oldin;                    /* number of inputs to the old weave */
+word newin;                    /* number of inputs to the new weave */
+
 void b_manip(weave *oldweaves)
 {
-  extern word list[BIGWEAVE];              /* description of first new weave */
-  extern word list2[BIGWEAVE];           /* description of second, if needed */
-  extern word old_going_in[BIGWEAVE];/* Was *i* an input? *old_going_in[i]*. */
-  extern word going_in[BIGWEAVE];    /* Will *i* be an input? *going_in[i]*. */
-  extern word map[BIGWEAVE];   /* i of old weave becomes map[i] of new weave */
-  extern word first;                    /* first boundary crossing to remove */
-  extern word second;                  /* second boundary crossing to remove */
-  extern word right;          /* Is the crossing being added be righthanded? */
-  extern word oldcross;     /* number of boundary crossings in the old weave */
-  extern word newcross;    /* number of boundary crossings in each new weave */
-  extern word oldin;                    /* number of inputs to the old weave */
-  extern word newin;                    /* number of inputs to the new weave */
-
   word       i, j, k;
   ub4        boundary[2];
 

--- a/lib/bound.h
+++ b/lib/bound.h
@@ -44,21 +44,21 @@ typedef struct weave weave;
 
 /*
 ---------------------------------------------------------------------------
-  Global Variables
+  Global Variables -- located in bound.c 
 ---------------------------------------------------------------------------
 */
-word       list[BIGWEAVE];                 /* description of first new weave */
-word       list2[BIGWEAVE];              /* description of second, if needed */
-word       old_going_in[BIGWEAVE];   /* Was *i* an input? *old_going_in[i]*. */
-word       going_in[BIGWEAVE];       /* Will *i* be an input? *going_in[i]*. */
-word       map[BIGWEAVE];      /* i of old weave becomes map[i] of new weave */
-word       first;                       /* first boundary crossing to remove */
-word       second;                     /* second boundary crossing to remove */
-word       right;                /* Is the crossing being added righthanded? */
-word       oldcross;        /* number of boundary crossings in the old weave */
-word       newcross;       /* number of boundary crossings in each new weave */
-word       oldin;                       /* number of inputs to the old weave */
-word       newin;                       /* number of inputs to the new weave */
+extern word       list[];                 /* description of first new weave */
+extern word       list2[];              /* description of second, if needed */
+extern word       old_going_in[];   /* Was *i* an input? *old_going_in[i]*. */
+extern word       going_in[];       /* Will *i* be an input? *going_in[i]*. */
+extern word       map[];      /* i of old weave becomes map[i] of new weave */
+extern word       first;                       /* first boundary crossing to remove */
+extern word       second;                     /* second boundary crossing to remove */
+extern word       right;                /* Is the crossing being added righthanded? */
+extern word       oldcross;        /* number of boundary crossings in the old weave */
+extern word       newcross;       /* number of boundary crossings in each new weave */
+extern word       oldin;                       /* number of inputs to the old weave */
+extern word       newin;                       /* number of inputs to the new weave */
 
 /*
 ---------------------------------------------------------------------------

--- a/lib/control.c
+++ b/lib/control.c
@@ -15,15 +15,17 @@ Public Domain
 #include "model.h"
 #include "control.h"
 
+Instruct   plan;
+Poly   llplus;
+Poly   lplusm;
+Poly   lminusm;
+Poly   llminus;
+Poly   mll;
+ub4    total_weaves_handled;
+
 /* these variables are global, and may be because nobody ever changes them */
 void c_init()
 {
-  extern Poly   llplus;
-  extern Poly   lplusm;
-  extern Poly   lminusm;
-  extern Poly   llminus;
-  extern Poly   mll;
-  extern ub4    total_weaves_handled;
   Poly          blank[1];
 
   p_init(blank);

--- a/lib/control.h
+++ b/lib/control.h
@@ -11,15 +11,15 @@
 #include "poly.h"
 #include "order.h"
 
-/* Global variables */
+/* Global variables -- located in control.c */
 
-Instruct   plan;       /* plan of what to do to each old weave for this step */
-Poly       llplus;                                                   /* -L^2 */
-Poly       lplusm;                                                    /* -LM */
-Poly       lminusm;                                              /* -(L^-1)M */
-Poly       llminus;                                                 /* -L^-2 */
-Poly       mll;                                       /* (M^-1)(-(L^-1) - L) */
-ub4        total_weaves_handled;             /* how much work has been done? */
+extern Instruct   plan;       /* plan of what to do to each old weave for this step */
+extern Poly       llplus;                                                   /* -L^2 */
+extern Poly       lplusm;                                                    /* -LM */
+extern Poly       lminusm;                                              /* -(L^-1)M */
+extern Poly       llminus;                                                 /* -L^-2 */
+extern Poly       mll;                                       /* (M^-1)(-(L^-1) - L) */
+extern ub4        total_weaves_handled;             /* how much work has been done? */
 
 /*
 ------------------------------------------------------------------------------

--- a/lib/knot.c
+++ b/lib/knot.c
@@ -70,7 +70,7 @@ void k_show(Link *link)
   Assumes the file given by the user exists and contains a legal knot.
 ------------------------------------------------------------------------------
 */
-boolean k_read(Link **link, char *filename)
+boolean k_read(Link **link, char *f)
 {
   char       name[20];
   word       links,
@@ -80,31 +80,32 @@ boolean k_read(Link **link, char *filename)
              over,
              i,
              j;
-  int        num_crossings;
+  int        num_crossings, pos;
   crossing  *kk;
   crossing   k[MAXCROSS];
-  FILE      *f;
 
   for (i = 0; i < MAXCROSS; i++) k[i].hand = 0;
 
-  f = fmemopen(filename, strlen(filename), "r");
   if (f == 0)
   {
-    fclose(f);
     return FALSE;
   }
-  fscanf(f, "%d ", &links);
+  sscanf(f, "%d%n", &links, &pos);
+  f += pos;
   for (i=0; i<links; ++i)                    /* how many pieces of string */
   {
-    fscanf(f, "%d ", &num_crossings);
-    fscanf(f, "%d %d ", &startwhere, &startover);
+    sscanf(f, "%d%n", &num_crossings, &pos);
+    f += pos;
+    sscanf(f, "%d %d%n", &startwhere, &startover, &pos);
+    f += pos;
     if (startover == 1)
       l_add((dllink *)0, startwhere, &k[startwhere].o);
     else
       l_add((dllink *)0, startwhere, &k[startwhere].u);
     for (j=1; j<num_crossings; ++j)
     {
-      fscanf(f, "%d %d ", &where, &over);
+      sscanf(f, "%d %d%n", &where, &over, &pos);
+      f += pos;
 
       /* check that OVER is legal */
       if ((over != 1) && (over != -1))
@@ -130,13 +131,13 @@ boolean k_read(Link **link, char *filename)
     }
   }
   num_crossings = 0;
-  while (fscanf(f, "%d %d ", &where, &over) == 2)
+  while (sscanf(f, "%d %d%n", &where, &over, &pos) == 2)
   {
+    f += pos;
     k[where].hand = over;
     if (where > num_crossings) num_crossings = where;
   }
   ++num_crossings;
-  i = fclose(f);
 
   kk = (crossing *)GC_MALLOC(sizeof(crossing) * num_crossings);
   for (i=0; i < num_crossings; ++i) kk[i] = k[i];

--- a/lib/poly.c
+++ b/lib/poly.c
@@ -68,14 +68,15 @@ char *p_show(Poly *p)
   sb4    l;
   char *bp;
   size_t size;
-  FILE *stream;
+  char *stream;
+  int pos;
 
 
-  stream = open_memstream(&bp, &size);
+  stream = (char *)GC_MALLOC(sizeof(char) * 100000);
+  bp = stream;
   if (!p->len)
   {
-    fprintf(stream, "0");
-    fclose(stream);
+    sprintf(stream, "0");
     return bp;
   }
 
@@ -84,24 +85,33 @@ char *p_show(Poly *p)
     if (!pt->coef) continue;
     m = p_sign(pt->m);
     l = p_sign(pt->l);
-    if (pt->coef < ((sb4)0)) fprintf(stream, " - ");
-    else if (!first) fprintf(stream, " + ");
-    if (pt->coef > ((sb4)1) ) fprintf(stream, "%ld", pt->coef);
-    else if (pt->coef < (sb4)(-1)) fprintf(stream, "%ld", -pt->coef);
-    else if ((!l) && (!m)) fprintf(stream, "%d", 1);
+    if (pt->coef < ((sb4)0)) { sprintf(stream, " - "); stream += 3; }
+    else if (!first) { sprintf(stream, " + "); stream += 3; }
+    pos = 0;
+    if (pt->coef > ((sb4)1) ) sprintf(stream, "%ld%n", pt->coef, &pos);
+    else if (pt->coef < (sb4)(-1)) sprintf(stream, "%ld%n", -pt->coef, &pos);
+    else if ((!l) && (!m)) sprintf(stream, "%d%n", 1, &pos);
+    stream += pos;
     if (pt->m)
     {
-      fprintf(stream, "M");
-      if (m != 1) fprintf(stream, "^%ld", m);
+      sprintf(stream, "M");
+      stream++;
+      if (m != 1) {
+        sprintf(stream, "^%ld%n", m, &pos);
+        stream += pos;
+      }
     }
     if (pt->l)
     {
-      fprintf(stream, "L");
-      if (l != 1) fprintf(stream, "^%ld", l);
+      sprintf(stream, "L");
+      stream++;
+      if (l != 1) {
+         sprintf(stream, "^%ld%n", l, &pos);
+         stream += pos;
+      }
     }
     if (first) first = 0;
   }
-  fclose(stream);
   return bp;
 }
 

--- a/lib/poly.c
+++ b/lib/poly.c
@@ -76,7 +76,7 @@ char *p_show(Poly *p)
   {
     fprintf(stream, "0");
     fclose(stream);
-    return NULL;
+    return bp;
   }
 
   for (first = 1, pt = p->term, pend = pt+p->len; pt != pend; ++pt)

--- a/lib/poly.c
+++ b/lib/poly.c
@@ -76,7 +76,7 @@ char *p_show(Poly *p)
   {
     fprintf(stream, "0");
     fclose(stream);
-    return;
+    return NULL;
   }
 
   for (first = 1, pt = p->term, pend = pt+p->len; pt != pend; ++pt)


### PR DESCRIPTION
Global data should be allocated in *.c
files, and declared (with extern qualifier) in *.h
Otherwise it is asking for trouble (surely it does not work on OSX).

As well, a non-void function cannot have "return;" - fixed that too.