### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,15 @@ matrix:
       apt:
         packages:
         - libgc-dev
-
+  #powerjobs
+  - os: linux
+    arch: ppc64le
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - libgc-dev
+  
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bdw-gc  ; fi


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
